### PR TITLE
take the shortest path when animating using playTo method…

### DIFF
--- a/src/AnimateImages.js
+++ b/src/AnimateImages.js
@@ -252,7 +252,20 @@ export default class AnimateImages{
         if (frameNumber > this.#data.currentFrame)   this.setReverse(false); // move forward
         else  this.setReverse(true); // move backward
 
-        return this.playFrames(Math.abs(frameNumber - this.#data.currentFrame))
+        let numberOfFramesToPlay = Math.abs(frameNumber - this.#data.currentFrame);
+
+        if (this.#settings.loop && numberOfFramesToPlay > this.#data.totalImages / 2) {
+          // take the shortest path
+          if (this.#data.currentFrame > frameNumber) {
+            numberOfFramesToPlay = (this.#data.totalImages - this.#data.currentFrame) + frameNumber;
+            this.setReverse(false);
+          } else {
+            numberOfFramesToPlay = (this.#data.totalImages - frameNumber) + this.#data.currentFrame;
+            this.setReverse(true);
+          }
+        }
+
+        return this.playFrames(numberOfFramesToPlay);
     }
     /**
      * Start animation in the current direction with the specified number of frames in the queue


### PR DESCRIPTION
…if loop setting is enabled

e.g. there are total of 90 frames, current frame is 2 and the frame to play to is 88, it will play backwards (2, 1, 90, 89, 88), instead of forwards (2, 3, 4 .. 86, 87, 88)